### PR TITLE
Web service release triggers doker image build and push

### DIFF
--- a/.github/workflows/on-release-update-docker.yml
+++ b/.github/workflows/on-release-update-docker.yml
@@ -12,5 +12,5 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.pat_external_workflow }}
-          repository: jmillanacosta/docker
+          repository: bridgedb/docker
           event-type: update-event

--- a/.github/workflows/on-release-update-docker.yml
+++ b/.github/workflows/on-release-update-docker.yml
@@ -1,6 +1,8 @@
 name: Update Docker image
 on:
   release:
+    #types: [published]
+
   
 jobs:
   trigger-docker-update:

--- a/.github/workflows/on-release-update-docker.yml
+++ b/.github/workflows/on-release-update-docker.yml
@@ -1,0 +1,14 @@
+name: Update Docker image
+on:
+  release:
+  
+jobs:
+  trigger-docker-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docker release
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.pat_external_workflow }}
+          repository: jmillanacosta/docker
+          event-type: update-event


### PR DESCRIPTION
Fixes #6 , test run here: https://github.com/jmillanacosta/BridgeDbWebservice/actions/runs/4302543852 which triggered this: https://github.com/jmillanacosta/docker/actions/runs/4302542355 

Needs a PAT (in my experience better to create a classic PAT, not fine-grained) with `workflow` scopes in order to work.
