### PR TITLE
Update BDBVERSION in pom.xml

### DIFF
--- a/.github/workflows/on-release-update-docker.yml
+++ b/.github/workflows/on-release-update-docker.yml
@@ -2,7 +2,7 @@ name: Update Docker image
 on:
   release:
     #types: [published]
-
+  push: #test, to be removed
   
 jobs:
   trigger-docker-update:

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <restlet-version>2.4.3</restlet-version>
-    <bridgedb-version>3.1.1</bridgedb-version>
+    <bridgedb-version>3.0.25</bridgedb-version>
     <junit.version>5.10.1</junit.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <restlet-version>2.4.3</restlet-version>
-    <bridgedb-version>3.0.25</bridgedb-version>
+    <bridgedb-version>3.1.1</bridgedb-version>
     <junit.version>5.10.1</junit.version>
   </properties>
 


### PR DESCRIPTION
The version of BridgeDB used to build the new docker upon ping from the repo uses the following code to get the `BDBVERSION`:

https://github.com/bridgedb/docker/blob/fc06a5f214797e0b76a461fee4b7d99a4fe5ae21/.github/workflows/buildandpush.yml#L42C18-L42C92

Meaning this POM needs to be updated too. This patch fixes the issue for now, but what will the workflow be to automate this?