### PR TITLE
Restore plain text (TSV) as the default REST response format

### DIFF
--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/AttributeSearch.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/AttributeSearch.java
@@ -47,7 +47,7 @@ public class AttributeSearch extends RestletResource {
 			if (attribute == null) attribute = "Symbol"; // use symbol by default.
 			Map<Xref, String> results = stack.freeAttributeSearch(searchStr, attribute, limit);
 
-			if (MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())) {
+			if (RestletResource.jsonRequested(getClientInfo())) {
 				JSONObject jsonObject = new JSONObject();
 				JSONObject attributeSearchResult = new JSONObject();
 				for (Xref x : results.keySet()) {

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/AttributeSet.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/AttributeSet.java
@@ -26,7 +26,7 @@ public class AttributeSet extends RestletResource {
 		try {
 			IDMapperStack stack = getIDMappers();
 			Set<String> attributes = stack.getAttributeSet();
-			if (MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())) {
+			if (RestletResource.jsonRequested(getClientInfo())) {
 				JSONObject jsonObject = new JSONObject();
 				List<String> resultSet = new ArrayList<>();
 				for (String a : attributes) {

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/Attributes.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/Attributes.java
@@ -60,7 +60,7 @@ public class Attributes extends RestletResource {
 	}
 	
 	private Representation getAttributesWithType(Variant variant) throws IDMapperException {
-		if(MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())){
+		if(RestletResource.jsonRequested(getClientInfo())){
 			IDMapperStack mapper = getIDMappers();
 			JSONObject jsonObject = new JSONObject();
 			Set<String> values = mapper.getAttributes(xref, attrType);
@@ -84,7 +84,7 @@ public class Attributes extends RestletResource {
 	private Representation getAttributesWithoutType(Variant variant) throws IDMapperException {
 		IDMapperStack mapper = getIDMappers();
 		Map<String, Set<String>> values = mapper.getAttributes(xref);
-		if(MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())){
+		if(RestletResource.jsonRequested(getClientInfo())){
 			JSONObject jsonObject = new JSONObject();
 			for(String attr : values.keySet()) {
 				for(String v : values.get(attr)) {

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/Batch.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/Batch.java
@@ -69,7 +69,7 @@ public class Batch extends RestletResource {
 			String[] splitXrefs = postBody.split("\n");
 			IDMapper mapper = getIDMappers();
 			
-			if (MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())) {
+			if (RestletResource.jsonRequested(getClientInfo())) {
 				JSONObject jsonObject = new JSONObject();
 				for (String line : splitXrefs) {
 					JSONObject mappedXrefsJson = new JSONObject();
@@ -155,7 +155,7 @@ public class Batch extends RestletResource {
 			String[] splitXrefs = entity.getText().split("\n");
 			IDMapper mapper = getIDMappers();
 
-			if (MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())) {
+			if (RestletResource.jsonRequested(getClientInfo())) {
 				JSONObject jsonObject = new JSONObject();
 				List<String> resultSet = new ArrayList<>();
 				for (String id : splitXrefs) {

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/Config.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/Config.java
@@ -4,7 +4,6 @@ import java.util.Properties;
 
 import org.bridgedb.BridgeDb;
 import org.json.simple.JSONObject;
-import org.restlet.data.MediaType;
 import org.restlet.data.Status;
 import org.restlet.representation.Representation;
 import org.restlet.representation.StringRepresentation;
@@ -21,7 +20,7 @@ public class Config extends ServerResource {
 			props.load(BridgeDb.class.getClassLoader().getResourceAsStream("version.props"));
 			props.load(RestletServer.class.getClassLoader().getResourceAsStream("webservice.props"));
 
-			if (MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())) {
+			if (RestletResource.jsonRequested(getClientInfo())) {
 		        JSONObject jsonObject = new JSONObject();
 		        jsonObject.put("java.version", System.getProperty("java.version"));
 		        jsonObject.put("bridgedb.version", props.getProperty("bridgedb.version"));

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/Contents.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/Contents.java
@@ -3,7 +3,6 @@ package org.bridgedb.webservicetesting.BridgeDbWebservice;
 import org.bridgedb.bio.Organism;
 import org.bridgedb.rdb.GdbProvider;
 import org.json.simple.JSONObject;
-import org.restlet.data.MediaType;
 import org.restlet.data.Status;
 import org.restlet.representation.Representation;
 import org.restlet.representation.StringRepresentation;
@@ -18,7 +17,7 @@ public class Contents extends RestletResource {
 			return new StringRepresentation("\n");
 		}
 		try {
-			if (MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())) {
+			if (RestletResource.jsonRequested(getClientInfo())) {
 		        JSONObject jsonObject = new JSONObject();
 				for (Organism org : getGdbProvider().getOrganisms()) {
 		        	jsonObject.put(org.shortName(), org.latinName());

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/DataSources.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/DataSources.java
@@ -7,7 +7,6 @@ import java.io.InputStreamReader;
 
 import org.bridgedb.bio.DataSourceTxt;
 import org.json.simple.JSONObject;
-import org.restlet.data.MediaType;
 import org.restlet.representation.Representation;
 import org.restlet.representation.StringRepresentation;
 import org.restlet.representation.Variant;
@@ -18,7 +17,7 @@ public class DataSources extends ServerResource{
 
 	@Get
 	public Representation get(Variant variant) {
-		if(MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())){
+		if(RestletResource.jsonRequested(getClientInfo())){
 			String datasourcesTxt = "";
 			String datasourcesHeaders = "";
 			InputStream headers = DataSourceTxt.class.getClassLoader().getResourceAsStream("org/bridgedb/bio/datasources_headers.tsv");	

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/IsFreeSearchSupported.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/IsFreeSearchSupported.java
@@ -22,7 +22,7 @@ public class IsFreeSearchSupported extends RestletResource {
 		try {
 			IDMapper mapper = getIDMappers();
 			boolean isSupported = mapper.getCapabilities().isFreeSearchSupported();
-			if(MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())){
+			if(RestletResource.jsonRequested(getClientInfo())){
 				JSONObject jsonObject = new JSONObject();
 				jsonObject.put("isSupported", isSupported);
 				return new StringRepresentation(jsonObject.toString());

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/IsMappingSupported.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/IsMappingSupported.java
@@ -46,7 +46,7 @@ public class IsMappingSupported extends RestletResource {
 		try {
 			IDMapper m = getIDMappers();
 			boolean supported = m.getCapabilities().isMappingSupported(srcDs, destDs);
-			if (MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())) {
+			if (RestletResource.jsonRequested(getClientInfo())) {
 		        JSONObject jsonObject = new JSONObject();
 		        jsonObject.put("supported: ", "" + supported);
 				return new StringRepresentation(jsonObject.toString());

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/Properties.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/Properties.java
@@ -21,7 +21,7 @@ public class Properties extends RestletResource{
 			return sr;
     	}
     	
-		if(MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())){
+		if(RestletResource.jsonRequested(getClientInfo())){
 			try
 			{
 		        JSONObject jsonObject = new JSONObject();

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/RestletResource.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/RestletResource.java
@@ -9,6 +9,9 @@ import org.bridgedb.DataSource;
 import org.bridgedb.IDMapperStack;
 import org.bridgedb.bio.Organism;
 import org.bridgedb.rdb.GdbProvider;
+import org.restlet.data.ClientInfo;
+import org.restlet.data.MediaType;
+import org.restlet.data.Preference;
 import org.restlet.resource.ResourceException;
 import org.restlet.resource.ServerResource;
 
@@ -115,5 +118,34 @@ public class RestletResource extends ServerResource {
 		private GdbProvider getGdbProvider() {
 			return ((RestletService)getApplication()).getGdbProvider();
 		}
-	 
+
+	/**
+	 * Returns whether the client explicitly requested a JSON response.
+	 *
+	 * <p>Only an explicit {@code Accept: application/json} yields JSON; every
+	 * other case (a wildcard {@code Accept: *​/*}, {@code text/plain}, or no
+	 * Accept header at all) falls back to the plain-text (TSV) default.
+	 *
+	 * <p>The resources previously decided this by testing
+	 * {@code APPLICATION_JSON.isCompatible(variant.getMediaType())} against the
+	 * content-negotiated variant. That test also matches wildcard media types,
+	 * and the media type of the negotiated {@code variant} depends on the
+	 * Restlet version's content negotiation. As a result the default response
+	 * format silently flipped from TSV to JSON after the Restlet 2.4.3 -&gt;
+	 * 2.4.4 upgrade, without any change to this code. Reading the client's
+	 * Accept header directly and matching {@code application/json} exactly keeps
+	 * the default stable.
+	 */
+	public static boolean jsonRequested(ClientInfo clientInfo) {
+		if (clientInfo == null) {
+			return false;
+		}
+		for (Preference<MediaType> accepted : clientInfo.getAcceptedMediaTypes()) {
+			if (MediaType.APPLICATION_JSON.equals(accepted.getMetadata())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 }

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/SupportedSourceDataSources.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/SupportedSourceDataSources.java
@@ -25,7 +25,7 @@ public class SupportedSourceDataSources extends RestletResource {
     	}
 		try {
 			IDMapper mapper = getIDMappers();
-			if (MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())) {
+			if (RestletResource.jsonRequested(getClientInfo())) {
 		        JSONObject jsonObject = new JSONObject();
 				List<String> resultSet = new ArrayList<>();
 				for (DataSource ds : mapper.getCapabilities().getSupportedSrcDataSources()) {

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/SupportedTargetDataSources.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/SupportedTargetDataSources.java
@@ -25,7 +25,7 @@ public class SupportedTargetDataSources extends RestletResource {
     	}
 		try {
 			IDMapper mapper = getIDMappers();
-			if (MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())) {
+			if (RestletResource.jsonRequested(getClientInfo())) {
 				JSONObject jsonObject = new JSONObject();
 				List<String> resultSet = new ArrayList<>();
 				for (DataSource ds : mapper.getCapabilities().getSupportedTgtDataSources()) {

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/XrefExists.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/XrefExists.java
@@ -41,7 +41,7 @@ public class XrefExists extends RestletResource {
     	}
 		try {
 			IDMapper mapper = getIDMappers();
-			if (MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())) {
+			if (RestletResource.jsonRequested(getClientInfo())) {
 				JSONObject jsonObject = new JSONObject();
 				jsonObject.put("exists",mapper.xrefExists(xref));
 				return new StringRepresentation(jsonObject.toString());

--- a/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/Xrefs.java
+++ b/src/main/java/org/bridgedb/webservicetesting/BridgeDbWebservice/Xrefs.java
@@ -70,7 +70,7 @@ public class Xrefs extends RestletResource{
 				xrefs = mapper.mapID(xref);
 			else
 				xrefs = mapper.mapID(xref, targetDs);
-			if(MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())){
+			if(RestletResource.jsonRequested(getClientInfo())){
 		        JSONObject jsonObject = new JSONObject();
 				for(Xref x : xrefs) {
 					if (targetSystemCode == null ||


### PR DESCRIPTION
## Summary

All REST endpoints currently return **JSON by default**, even for clients that ask for plain text or send no `Accept` header. The webservice is documented (and historically behaves) to return two-column **TSV** with `Content-Type: text/plain` by default, and JSON only when it is explicitly requested. This regressed in 2.1.8 without any change to the resource code.

## Root cause

Each resource picks the output format with:

```java
if (MediaType.APPLICATION_JSON.isCompatible(variant.getMediaType())) { /* JSON */ }
else { /* TSV  */ }
```

`MediaType.isCompatible()` also matches wildcard media types (`*/*`, `application/*`), and `variant.getMediaType()` is whatever Restlet's content negotiation resolves. Release 2.1.8 bumped **Restlet 2.4.3 -> 2.4.4** (see `pom.xml`); under 2.4.4 the negotiated variant resolves to a JSON-compatible media type for ordinary requests, so the JSON branch is taken for:

- `Accept: */*` (curl, browsers, most HTTP client libraries)
- requests with no `Accept` header
- `Accept: text/plain`

i.e. effectively every client. Because the JSON `StringRepresentation` is returned without setting its media type, the response is additionally labelled `Content-Type: text/plain` while carrying a JSON body.

## Fix

Decide the format from the client's `Accept` header directly rather than from the negotiated variant. A small helper on `RestletResource`:

```java
public static boolean jsonRequested(ClientInfo clientInfo)
```

returns `true` only when `application/json` is explicitly present in the client's accepted media types; every other case (wildcard, `text/plain`, or none) falls back to plain text. All 16 call sites across 14 resources now use it, so the default no longer depends on Restlet's negotiation behaviour and is stable across dependency upgrades.

`mvn compile` passes against Restlet 2.4.4 / BridgeDb 3.0.29.

## Possible follow-up (not in this PR)

The JSON branches build `new StringRepresentation(json.toString())` without `setMediaType(MediaType.APPLICATION_JSON)`, so JSON responses are served with `Content-Type: text/plain`. Setting the media type there would make the labelling correct when JSON *is* requested. I kept this PR limited to restoring the default format, but happy to fold that in.

## How to verify

```bash
# default -> tab-separated, Content-Type: text/plain
curl -s -D - http://<host>/Human/xrefs/L/1234
# explicit JSON -> JSON body
curl -s -D - -H 'Accept: application/json' http://<host>/Human/xrefs/L/1234
# plain text stays plain text
curl -s -H 'Accept: text/plain' http://<host>/Human/xrefs/L/1234
```
