### PR TITLE
Register Derby driver in fat jar (fix HTTP 500 on all mapping requests)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,25 +166,37 @@
         </executions>
       </plugin>
       <plugin>
+        <!--
+          Shade (not assembly) builds the fat jar so that META-INF/services/*
+          service descriptors are MERGED across dependencies. The old
+          assembly:jar-with-dependencies clobbered them: the MySQL connector's
+          META-INF/services/java.sql.Driver overwrote Derby's, so the Derby
+          EmbeddedDriver never auto-registered and no .bridge (embedded Derby)
+          database could be opened (every request returned HTTP 500).
+          ServicesResourceTransformer concatenates the descriptors so both the
+          Derby and MySQL drivers stay registered. shadedClassifierName keeps
+          the released artifact name "<artifactId>-<version>-jar-with-dependencies.jar".
+        -->
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.7.1</version>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <phase>package</phase>
             <goals>
-              <goal>single</goal>
+              <goal>shade</goal>
             </goals>
             <configuration>
-              <archive>
-                <manifest>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.bridgedb.webservicetesting.BridgeDbWebservice.RestletServer</mainClass>
-                </manifest>
-                </archive>
-                <descriptorRefs>
-                  <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-              </configuration>
+                </transformer>
+              </transformers>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Problem

The `2.1.8` `jar-with-dependencies` ships a **clobbered** `META-INF/services/java.sql.Driver`: during the `maven-assembly-plugin` build, the MySQL connector's service descriptor overwrites Derby's, so only `com.mysql.cj.jdbc.Driver` ends up registered. Because the `.bridge` mapping files are embedded Derby databases, `DriverManager` then has no Derby driver, no database can be opened, and **every request returns HTTP 500**.

Reproduce on a `2.1.8` fat jar:
```
jar xf BridgeDbWebservice-2.1.8-jar-with-dependencies.jar META-INF/services/java.sql.Driver
cat META-INF/services/java.sql.Driver   # -> only com.mysql.cj.jdbc.Driver
```

## Fix

Build the fat jar with `maven-shade-plugin` + `ServicesResourceTransformer`, which *merges* `META-INF/services/*` across dependencies so the Derby and MySQL `java.sql.Driver` entries are concatenated. `shadedClassifierName=jar-with-dependencies` keeps the released artifact name unchanged (`<artifactId>-<version>-jar-with-dependencies.jar`), so downstream consumers (e.g. `bridgedb/docker`) are unaffected. This removes the need for the runtime workaround currently carried in `bridgedb/docker` (`startup.sh` passing `-Djdbc.drivers=org.apache.derby.jdbc.EmbeddedDriver`).

## Validated locally

- Shaded jar's `META-INF/services/java.sql.Driver` now lists **all three**: `com.mysql.cj.jdbc.Driver`, `org.apache.derby.iapi.jdbc.AutoloadedDriver`, `org.apache.derby.client.ClientAutoloadedDriver`.
- Running the built jar **without** `-Djdbc.drivers` against a real `.bridge` opens the Derby DB and maps correctly (`Human/xrefs/H/BRCA2` → xrefs incl. UniProt P51587, Ensembl ENSG00000139618).
- Full test suite: `Tests run: 61, Failures: 0, Errors: 0`.
